### PR TITLE
Update gdl-dock-item-grip.c

### DIFF
--- a/gdl/gdl-dock-item-grip.c
+++ b/gdl/gdl-dock-item-grip.c
@@ -401,7 +401,9 @@ gdl_dock_item_grip_realize (GtkWidget *widget)
         GdkWindowAttr  attributes;
         GdkCursor     *cursor;
 
-        g_return_if_fail (grip->priv->label != NULL);
+        if (grip->priv->label == NULL) {
+            gdl_dock_item_grip_set_label (grip, gdl_dock_item_create_label_widget(grip) );
+        }
 
         gtk_widget_get_allocation (widget, &allocation);
 


### PR DESCRIPTION
Fixed assertion that was hitting on both linux and windows that prevented dockbars from having a grip and being unable to be dragged.

It seemed like regardless of the label being created or not this would be triggered after creating more docks or dragging and dropping one.

Looked like all the data is there to create the label if it's null so I simply removed the assertion and made it create the label which fixed the issue for me and no longer produces assertion errors.

Would love to get this upstreamed.